### PR TITLE
Prevent sudo to be applied during the API call

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,3 +17,4 @@
     body: "{{ hostvars[inventory_hostname] | to_json }}"
     status_code: 201 # Created
   connection: local
+  sudo: no


### PR DESCRIPTION
Otherwise if `sudo: yes` is specified at the playbook level, the sudo password of the managed node is used to make the API call, which is run on the managing machine.
